### PR TITLE
Add verbose handler

### DIFF
--- a/src/HelperFunctions.py
+++ b/src/HelperFunctions.py
@@ -1,0 +1,29 @@
+from TextStrings import get_language_text
+
+
+def singleton(class_):
+    instances = {}
+
+    def getinstance(*args, **kwargs):
+        if class_ not in instances:
+            instances[class_] = class_(*args, **kwargs)
+        return instances[class_]
+    return getinstance
+
+
+@singleton
+class HelperFunctions:
+    def __init__(self, options=None):
+        self.options = options
+
+    def get_verbose(self):
+        return self.options['verbose']
+
+    def get_options(self):
+        return self.options
+
+
+def print_verbose(text, *args, indent=0):
+    if HelperFunctions().get_options()['verbose']:
+        print('\t'*indent, end='')
+        print(get_language_text(text, *args, lang=HelperFunctions().get_options()['language']))

--- a/src/TextStrings.py
+++ b/src/TextStrings.py
@@ -1,0 +1,52 @@
+TEXT_STRINGS = {
+    'Controller.set_pin_mode.pin.mode': {
+        'da': 'Sætter pin tilstand',
+        'en': 'Setting pin mode'
+    },
+    'Controller.set_pin_mode.pin.mode.as': {
+        'da': 'Sætter pin {} som {}',
+        'en': 'Setting pin {} as {}'
+    },
+    'Controller.set_pin_mode.saving.as': {
+        'da': 'Gemmer som {{ "pin": {}, "mode": "{}" }} til hukommelse',
+        'en': 'Saving as {{ "pin": {}, "mode": "{}" }} to memory'
+    },
+    'Controller.digital_write.writing.to': {
+        'da': 'Skriver til digital pin',
+        'en': 'Writing to digital pin'
+    },
+    'Controller.digital_write.writing.to.with': {
+        'da': 'Skriver {} til digital pin {}',
+        'en': 'Writing {} to digital pin {}'
+    },
+    'Controller.digital_read.reading.from': {
+        'da': 'Læser fra digital pin',
+        'en': 'Reading from digital pin'
+    },
+    'Controller.digital_read.reading.from.pin': {
+        'da': 'Læser fra digital pin {}',
+        'en': 'reading from digital pin {}'
+    },
+    'Controller.analog_write.writing.to': {
+        'da': 'Skriver til analog pin',
+        'en': 'Writing to analog pin'
+    },
+    'Controller.analog_write.writing.to.pin': {
+        'da': 'Skriver {} til analog pin {}',
+        'en': 'Writing {} to analog pin {}'
+    },
+    'Controller.analog_read.reading.from': {
+        'da': 'Læser fra analog pin',
+        'en': 'Reading from analog pin'
+    },
+    'Controller.analog_read.reading.from.pin': {
+        'da': 'Læser fra analog pin {}',
+        'en': 'Reading from analog pin {}'
+    }
+}
+
+
+def get_language_text(text, *args, lang='en'):
+    if text in TEXT_STRINGS:
+        return TEXT_STRINGS[text][lang].format(*args)
+    return ''

--- a/src/TextStrings.py
+++ b/src/TextStrings.py
@@ -1,3 +1,14 @@
+""""
+Naming convention:
+
+    Class.method_name.description: {
+        da,
+        en,
+        ?other
+    }
+
+"""
+
 TEXT_STRINGS = {
     'Controller.set_pin_mode.pin.mode': {
         'da': 'Sætter pin tilstand',

--- a/src/controllers/Connector.py
+++ b/src/controllers/Connector.py
@@ -16,14 +16,19 @@ class Connector:
         :return: Serial object
         """
         if self.verbose:
-            print('Connecting to port', self.serial_port + '...')
+            print('Connecting to port [' + self.serial_port + ']...', end='')
         try:
             self.conn = serial.Serial(self.serial_port, self.baud_rate)
             self.conn.timeout = self.read_timeout
-            return self.conn
+            if self.verbose:
+                print('Connected')
+            return True
         except Exception as e:
             print('\t[-]', e)
-            return None
+            return False
+
+    def get_serial_connection(self):
+        return self.conn
 
     def close_connection(self):
         """
@@ -36,7 +41,7 @@ class Connector:
         try:
             self.conn.close()
             if self.verbose:
-                print('\t', 'connection closed')
+                print('\tconnection closed')
             return True
         except Exception as e:
             print('\t[-]', e)

--- a/src/controllers/Controller.py
+++ b/src/controllers/Controller.py
@@ -3,6 +3,7 @@ sys.path.append('..')
 from formatters.ProtocolStringFormatter import ProtocolStringFormatter
 from validators.ParameterValidator import ParameterValidator
 from validators.ProtocolFormatValidator import ProtocolFormatValidator
+from HelperFunctions import print_verbose
 
 class Controller:
     def __init__(self, conn, verbose=False):
@@ -24,21 +25,16 @@ class Controller:
         if not ParameterValidator.validate_pin_modes(mode):
             return False
 
-        if self.verbose:
-            print('Setting pin mode')
-
+        print_verbose('Controller.set_pin_mode.pin.mode')
 
         try:
             command = ProtocolStringFormatter.format_single_pin_mode(pin_number, mode)
-
             if not ProtocolFormatValidator.validate_pin_mode(command):
                 return False
 
-            if self.verbose:
-                print('\t', 'setting pin', pin_number, 'as', mode)
+            print_verbose('Controller.set_pin_mode.pin.mode.as', pin_number, mode, indent=1)
             self.conn.write(command.encode())
-            if self.verbose:
-                print('\t', 'saving as {"pin": ' + str(pin_number) + ', "mode": "' + mode + '"} to local storage')
+            print_verbose('Controller.set_pin_mode.saving.as', pin_number, mode, indent=1)
             self.currentActivePins.append({'pin': pin_number, 'mode': mode})
             return True
         except Exception as e:
@@ -75,17 +71,14 @@ class Controller:
         if not ParameterValidator.validate_digital_range(digital_value):
             return False
 
-        if self.verbose:
-            print('Writing to digital pin')
+        print_verbose('Controller.digital_write.writing.to')
 
         try:
             command = ProtocolStringFormatter.format_digital_write(pin_number, digital_value)
-
             if not ProtocolFormatValidator.validate_write_action(command):
                 return False
 
-            if self.verbose:
-                print('\t', 'writing', digital_value, 'to digital pin', pin_number)
+            print_verbose('Controller.digital_write.writing.to.with', digital_value, pin_number, indent=1)
             self.conn.write(command.encode())
             return True
         except Exception as e:
@@ -102,18 +95,15 @@ class Controller:
         if not ParameterValidator.validate_pin_number(pin_number):
             return False
 
-        if self.verbose:
-            print('Reading from digital pin')
+        print_verbose('Controller.digital_read.reading.from')
 
         try:
             command = ProtocolStringFormatter.format_digital_read(pin_number)
-
             if not ProtocolFormatValidator.validate_read_action(command):
                 return False
 
             self.conn.write(command.encode())
-            if self.verbose:
-                print('\t', 'reading from digital pin', pin_number)
+            print_verbose('Controller.digital_read.reading.from.pin', pin_number, indent=1)
             line_received = self.conn.readline().decode().strip()
             header, value = line_received.split(':')
         except Exception as e:
@@ -138,17 +128,14 @@ class Controller:
         if not ParameterValidator.validate_analog_range(analog_value):
             return False
 
-        if self.verbose:
-            print('Writing to analog pin')
+        print_verbose('Controller.analog_write.writing.to')
 
         try:
             command = ProtocolStringFormatter.format_analog_write(pin_number, analog_value)
-
             if not ProtocolFormatValidator.validate_write_action(command):
                 return False
 
-            if self.verbose:
-                print('\t', 'writing', analog_value, 'to analog pin', pin_number)
+            print_verbose('Controller.analog_write.writing.to.pin', analog_value, pin_number, indent=1)
             self.conn.write(command.encode())
             return True
         except Exception as e:
@@ -165,18 +152,15 @@ class Controller:
         if not ParameterValidator.validate_pin_number(pin_number):
             return False
 
-        if self.verbose:
-            print('Reading from analog pin')
+        print_verbose('Controller.analog_read.reading.from')
 
         try:
             command = ProtocolStringFormatter.format_analog_read(pin_number)
-
             if not ProtocolFormatValidator.validate_read_action(command):
                 return False
 
             self.conn.write(command.encode())
-            if self.verbose:
-                print('\t', 'reading from analog pin', pin_number)
+            print_verbose('Controller.analog_read.reading.from.pin', pin_number)
             line_received = self.conn.readline().decode().strip()
             header, value = line_received.split(':')
         except Exception as e:

--- a/src/test/e2e.py
+++ b/src/test/e2e.py
@@ -2,14 +2,29 @@ import sys
 sys.path.append('..')
 from controllers.Connector import Connector
 from controllers.Controller import Controller
+from HelperFunctions import HelperFunctions
+
+VERBOSE = True
+SERIAL_PORT = 'COM3'
+READ_TIMEOUT = 1
+LANGUAGE = 'en'
 
 if __name__ == '__main__':
-    connector = Connector(serial_port='COM3', read_timeout=1, verbose=True)
-    conn = connector.connect_to_serial_port()
+    connector = Connector(serial_port=SERIAL_PORT, read_timeout=READ_TIMEOUT, verbose=VERBOSE)
+    connector.connect_to_serial_port()
+    conn = connector.get_serial_connection()
+    options = {
+        'serial_port': SERIAL_PORT,
+        'read_timeout': READ_TIMEOUT,
+        'verbose': VERBOSE,
+        'language': LANGUAGE
+    }
+    HelperFunctions(options=options)
+
     if conn is None:
         raise Exception('[-] connect_to_serial_port failed')
 
-    controller = Controller(conn, verbose=True)
+    controller = Controller(conn, verbose=VERBOSE)
 
     if not controller.set_pin_mode(5, 'OUTPUT'):
         raise Exception('[-] set_pin_mode failed')


### PR DESCRIPTION
To avoid `if verbose: print('...')` everywhere i added a `print_verbose` method with a singleton handler. I implemented it with a TextString dictionary with hardcoded strings that can be formatted.