### PR TITLE
Test mocked serial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
 python:
-  - "3.5"
+  - "3.6"
 install:
   - pip install .
   - pip install -r requirements.txt

--- a/pyduino/HelperFunctions.py
+++ b/pyduino/HelperFunctions.py
@@ -22,6 +22,12 @@ class HelperFunctions:
     def get_options(self):
         return self.options
 
+    def get_environment(self):
+        if self.options is None:
+            return None
+
+        return self.options['env']
+
 
 def print_verbose(text, *args, indent=0):
     if HelperFunctions().get_options()['verbose']:

--- a/pyduino/controllers/Connector.py
+++ b/pyduino/controllers/Connector.py
@@ -1,5 +1,5 @@
 import serial
-from pyduino.HelperFunctions import singleton
+from pyduino.HelperFunctions import singleton, HelperFunctions
 
 
 @singleton
@@ -11,10 +11,18 @@ class Connector:
         self.baud_rate = baud_rate
         self.verbose = verbose
 
-        self.connect_to_serial_port()
+        if HelperFunctions().get_environment() == 'testing':
+            self.connect_to_test_serial_port()
+        else:
+            self.connect_to_serial_port()
 
     def get_connection(self) -> serial:
         return self.conn
+
+    def connect_to_test_serial_port(self):
+        self.serial_port = 'loop://'
+        self.conn = serial.serial_for_url(self.serial_port, 9600)
+        self.conn.timeout = self.read_timeout
 
     def connect_to_serial_port(self):
         """

--- a/pyduino/controllers/Pin.py
+++ b/pyduino/controllers/Pin.py
@@ -33,7 +33,7 @@ class DigitalPin(PinInterface):
             raise ValueError("pin_number must be a valid digital pin")
 
         if not Controller().set_pin_mode(pin_number, mode=mode):
-            raise Exception("Failed to set pin " + str(pin_number) + " to " + mode)
+            raise RuntimeError("Failed to set pin " + str(pin_number) + " to " + mode)
 
         self.conn = conn
         self.pin_number = pin_number

--- a/pyduino/test/DigitalPinTest.py
+++ b/pyduino/test/DigitalPinTest.py
@@ -1,0 +1,48 @@
+from pyduino.HelperFunctions import HelperFunctions
+from pyduino.controllers.Pin import *
+import unittest
+
+VERBOSE = True
+SERIAL_PORT = 'ttyACM'
+READ_TIMEOUT = 1
+LANGUAGE = 'en'
+options = {
+    'verbose': False,
+    'language': 'en',
+    'env': 'testing'
+}
+
+
+class DigitalPinTest(unittest.TestCase):
+    def setUp(self):
+        HelperFunctions(options=options)
+        connector = Connector(serial_port=SERIAL_PORT, read_timeout=READ_TIMEOUT, verbose=VERBOSE)
+        self.conn = connector.get_serial_connection()
+        self.controller = Controller(conn=self.conn, verbose=True)
+
+    def test_positive_digital_write(self):
+        pin = DigitalPin(self.conn, 8)
+        self.assertTrue(pin.write(0))
+        self.assertTrue(pin.write(1))
+
+    def test_positive_digital_read(self):
+        pin = DigitalPin(self.conn, 8, mode='INPUT')
+        self.assertEqual(pin.read(), '')
+
+    def test_raises_digital_read(self):
+        pin = DigitalPin(self.conn, 8)
+        with self.assertRaises(RuntimeError) as _:
+            pin.read()
+
+    def test_raises_digital_write(self):
+        pin = DigitalPin(self.conn, 8, mode='INPUT')
+        with self.assertRaises(RuntimeError) as _:
+            pin.write(1)
+
+    def test_raises_digital_pin_range(self):
+        with self.assertRaises(ValueError) as _:
+            pin = DigitalPin(self.conn, 14)
+
+    def test_raises_digital_pin_mode(self):
+        with self.assertRaises(RuntimeError) as _:
+            pin = DigitalPin(self.conn, 8, mode="TEST")


### PR DESCRIPTION
To test the serial without connecting to a real device I has to use
"loop://". This device will return errors when trying to read from it
and to prevent the errors a check was added to the digital read method
in the Controller.

To know when to use the loop device I added an environment variable to
the HelperFunctions options.

- add environment to HelperFunctions
- add getter to HelperFunctions
- fix Exception type in DigitalPin constructor
- add check in Connector class to use either testing env or default